### PR TITLE
Rename APIs in the rust crate to `deltalake` for good symmetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,25 +332,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.3",
- "crossbeam-epoch 0.8.2",
- "crossbeam-queue 0.2.3",
- "crossbeam-utils 0.7.2",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel 0.5.0",
- "crossbeam-deque 0.8.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-queue 0.3.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -359,18 +345,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -379,20 +355,9 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
+ "crossbeam-epoch",
+ "crossbeam-utils",
  "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -403,23 +368,9 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
-dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.0",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
@@ -431,18 +382,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2a58563f049aa3bae172bc4120f093b5901161c629f280a1f40ba55317d774"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -453,18 +394,6 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -526,7 +455,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
- "crossbeam 0.7.3",
+ "crossbeam",
  "fnv",
  "num_cpus",
  "parquet",
@@ -537,14 +466,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "delta"
+name = "deltalake"
 version = "0.1.1"
 dependencies = [
  "anyhow",
  "arrow",
  "bytes 0.5.6",
  "chrono",
- "crossbeam 0.8.0",
+ "crossbeam",
  "datafusion",
  "futures",
  "log",
@@ -561,18 +490,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "delta-python"
+name = "deltalake-python"
 version = "0.1.0"
 dependencies = [
- "delta",
+ "deltalake",
  "pyo3",
 ]
 
 [[package]]
-name = "delta-ruby"
+name = "deltalake-ruby"
 version = "0.1.0"
 dependencies = [
- "delta",
+ "deltalake",
  "helix",
 ]
 
@@ -1859,7 +1788,7 @@ dependencies = [
  "base64",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "delta-python"
+name = "deltalake-python"
 version = "0.1.0"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta.rs"
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 version = "0.12.*"
 features = ["extension-module"]
 
-[dependencies.delta]
+[dependencies.deltalake]
 path = "../rust"
 version = "0.*"
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate delta;
+extern crate deltalake;
 extern crate pyo3;
 
 use std::path::Path;
@@ -7,14 +7,14 @@ use pyo3::prelude::*;
 
 #[pyclass]
 struct RawDeltaTable {
-    _table: delta::DeltaTable,
+    _table: deltalake::DeltaTable,
 }
 
 #[pymethods]
 impl RawDeltaTable {
     #[new]
     fn new(table_path: &str) -> PyResult<Self> {
-        let table = delta::open_table(&table_path).unwrap();
+        let table = deltalake::open_table(&table_path).unwrap();
         Ok(RawDeltaTable { _table: table })
     }
 

--- a/ruby/Cargo.toml
+++ b/ruby/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "delta-ruby"
+name = "deltalake-ruby"
 version = "0.1.0"
 authors = ["R Tyler Croy <rtyler@brokenco.de>"]
 
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 helix = "*"
 
-[dependencies.delta]
+[dependencies.deltalake]
 path = "../rust"

--- a/ruby/lib/deltalake.rb
+++ b/ruby/lib/deltalake.rb
@@ -1,5 +1,5 @@
 require 'helix_runtime'
-require 'delta-ruby/native'
+require 'deltalake-ruby/native'
 
 module Deltalake
   def self.open_table(table_path)

--- a/ruby/src/lib.rs
+++ b/ruby/src/lib.rs
@@ -2,9 +2,9 @@
 
 #[macro_use]
 extern crate helix;
-extern crate delta;
+extern crate deltalake;
 
-use delta::DeltaTable;
+use deltalake::DeltaTable;
 use std::sync::Arc;
 
 
@@ -18,7 +18,7 @@ ruby! {
         def initialize(helix, table_path: String) {
             println!("initializing with {}", table_path);
 
-            let table = delta::open_table(&table_path).unwrap();
+            let table = deltalake::open_table(&table_path).unwrap();
             let actual = Arc::new(table);
 
             Table {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,13 +1,11 @@
 [package]
-name = "delta"
+name = "deltalake"
 version = "0.1.1"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta.rs"
 license = "Apache-2.0"
 keywords = ["deltalake", "delta", "datalake"]
 description = "Native Delta Lake implementation in Rust"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,5 +1,5 @@
 extern crate anyhow;
-extern crate delta;
+extern crate deltalake;
 
 use std::env;
 
@@ -11,7 +11,7 @@ fn main() -> anyhow::Result<()> {
     }
     let table_path = &args[1];
 
-    let table = delta::open_table(table_path)?;
+    let table = deltalake::open_table(table_path)?;
 
     println!("{}", table);
     println!("{:#?}", table.get_files());

--- a/rust/tests/dataframe_test.rs
+++ b/rust/tests/dataframe_test.rs
@@ -1,12 +1,12 @@
 extern crate arrow;
-extern crate delta;
+extern crate deltalake;
 #[cfg(feature = "rust-dataframe-ext")]
 extern crate rust_dataframe;
 
 #[cfg(feature = "rust-dataframe-ext")]
 use self::arrow::array::UInt64Array;
 #[cfg(feature = "rust-dataframe-ext")]
-use self::delta::DeltaDataframe;
+use self::deltalake::DeltaDataframe;
 #[cfg(feature = "rust-dataframe-ext")]
 use self::rust_dataframe::dataframe::DataFrame;
 

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -1,7 +1,7 @@
 extern crate arrow;
 #[cfg(feature = "datafusion-ext")]
 extern crate datafusion;
-extern crate delta;
+extern crate deltalake;
 
 #[cfg(feature = "datafusion-ext")]
 use self::arrow::array::UInt64Array;
@@ -12,7 +12,7 @@ use self::datafusion::execution::context::ExecutionContext;
 #[cfg(feature = "datafusion-ext")]
 fn test_datafusion_simple_query() {
     let mut ctx = ExecutionContext::new();
-    let table = delta::open_table("./tests/data/simple_table").unwrap();
+    let table = deltalake::open_table("./tests/data/simple_table").unwrap();
     ctx.register_table("demo", Box::new(table));
 
     let sql = "SELECT id FROM demo WHERE id > 5";

--- a/rust/tests/read_delta-0-2-0_test.rs
+++ b/rust/tests/read_delta-0-2-0_test.rs
@@ -1,8 +1,8 @@
-extern crate delta;
+extern crate deltalake;
 
 #[test]
 fn read_delta_2_0_table_without_version() {
-    let table = delta::open_table("./tests/data/delta-0.2.0").unwrap();
+    let table = deltalake::open_table("./tests/data/delta-0.2.0").unwrap();
     assert_eq!(table.version, 3);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -18,7 +18,7 @@ fn read_delta_2_0_table_without_version() {
     assert_eq!(tombstones.len(), 4);
     assert_eq!(
         tombstones[0],
-        delta::action::Remove {
+        deltalake::action::Remove {
             path: "part-00000-512e1537-8aaa-4193-b8b4-bef3de0de409-c000.snappy.parquet".to_string(),
             deletionTimestamp: 1564524298213,
             dataChange: false,
@@ -28,7 +28,7 @@ fn read_delta_2_0_table_without_version() {
 
 #[test]
 fn read_delta_2_0_table_with_version() {
-    let mut table = delta::open_table_with_version("./tests/data/delta-0.2.0", 0).unwrap();
+    let mut table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 0).unwrap();
     assert_eq!(table.version, 0);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -40,7 +40,7 @@ fn read_delta_2_0_table_with_version() {
         ],
     );
 
-    table = delta::open_table_with_version("./tests/data/delta-0.2.0", 2).unwrap();
+    table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 2).unwrap();
     assert_eq!(table.version, 2);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -52,7 +52,7 @@ fn read_delta_2_0_table_with_version() {
         ]
     );
 
-    table = delta::open_table_with_version("./tests/data/delta-0.2.0", 3).unwrap();
+    table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 3).unwrap();
     assert_eq!(table.version, 3);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -1,5 +1,5 @@
 extern crate chrono;
-extern crate delta;
+extern crate deltalake;
 extern crate utime;
 
 use std::path::Path;
@@ -8,7 +8,7 @@ use self::chrono::{DateTime, FixedOffset, Utc};
 
 #[test]
 fn read_simple_table() {
-    let table = delta::open_table("./tests/data/simple_table").unwrap();
+    let table = deltalake::open_table("./tests/data/simple_table").unwrap();
     assert_eq!(table.version, 4);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -26,7 +26,7 @@ fn read_simple_table() {
     assert_eq!(tombstones.len(), 31);
     assert_eq!(
         tombstones[0],
-        delta::action::Remove {
+        deltalake::action::Remove {
             path: "part-00006-63ce9deb-bc0f-482d-b9a1-7e717b67f294-c000.snappy.parquet".to_string(),
             deletionTimestamp: 1587968596250,
             dataChange: true
@@ -36,7 +36,7 @@ fn read_simple_table() {
 
 #[test]
 fn read_simple_table_with_version() {
-    let mut table = delta::open_table_with_version("./tests/data/simple_table", 0).unwrap();
+    let mut table = deltalake::open_table_with_version("./tests/data/simple_table", 0).unwrap();
     assert_eq!(table.version, 0);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -52,7 +52,7 @@ fn read_simple_table_with_version() {
         ],
     );
 
-    table = delta::open_table_with_version("./tests/data/simple_table", 2).unwrap();
+    table = deltalake::open_table_with_version("./tests/data/simple_table", 2).unwrap();
     assert_eq!(table.version, 2);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -68,7 +68,7 @@ fn read_simple_table_with_version() {
         ]
     );
 
-    table = delta::open_table_with_version("./tests/data/simple_table", 3).unwrap();
+    table = deltalake::open_table_with_version("./tests/data/simple_table", 3).unwrap();
     assert_eq!(table.version, 3);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -108,35 +108,35 @@ fn time_travel_by_ds() {
     }
 
     let mut table =
-        delta::open_table_with_ds("./tests/data/simple_table", "2020-05-01T00:47:31-07:00")
+        deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-01T00:47:31-07:00")
             .unwrap();
     assert_eq!(table.version, 0);
 
-    table = delta::open_table_with_ds("./tests/data/simple_table", "2020-05-02T22:47:31-07:00")
+    table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-02T22:47:31-07:00")
         .unwrap();
     assert_eq!(table.version, 1);
 
-    table = delta::open_table_with_ds("./tests/data/simple_table", "2020-05-02T23:47:31-07:00")
+    table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-02T23:47:31-07:00")
         .unwrap();
     assert_eq!(table.version, 1);
 
-    table = delta::open_table_with_ds("./tests/data/simple_table", "2020-05-03T22:47:31-07:00")
+    table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-03T22:47:31-07:00")
         .unwrap();
     assert_eq!(table.version, 2);
 
-    table = delta::open_table_with_ds("./tests/data/simple_table", "2020-05-04T22:47:31-07:00")
+    table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-04T22:47:31-07:00")
         .unwrap();
     assert_eq!(table.version, 3);
 
-    table = delta::open_table_with_ds("./tests/data/simple_table", "2020-05-05T21:47:31-07:00")
+    table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-05T21:47:31-07:00")
         .unwrap();
     assert_eq!(table.version, 3);
 
-    table = delta::open_table_with_ds("./tests/data/simple_table", "2020-05-05T22:47:31-07:00")
+    table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-05T22:47:31-07:00")
         .unwrap();
     assert_eq!(table.version, 4);
 
-    table = delta::open_table_with_ds("./tests/data/simple_table", "2020-05-25T22:47:31-07:00")
+    table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-25T22:47:31-07:00")
         .unwrap();
     assert_eq!(table.version, 4);
 }


### PR DESCRIPTION
This way all the native bindings are published as `deltalake` packages and
everything is consistently `deltalake`