### PR TITLE
Update parquet dependency to match arrow/datafusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,26 +65,6 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrow"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7277b39e5f419c207c5e01f56ad8a91ffcc78548b85d6bb083560a667b567e11"
-dependencies = [
- "chrono",
- "csv",
- "flatbuffers",
- "hex",
- "indexmap",
- "lazy_static",
- "num",
- "rand",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "arrow"
 version = "3.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow.git?rev=c02ed530f989c4e0343ca6ab494c17e7796ed9c1#c02ed530f989c4e0343ca6ab494c17e7796ed9c1"
 dependencies = [
@@ -142,6 +122,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -501,7 +487,7 @@ name = "datafusion"
 version = "3.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow.git?rev=c02ed530f989c4e0343ca6ab494c17e7796ed9c1#c02ed530f989c4e0343ca6ab494c17e7796ed9c1"
 dependencies = [
- "arrow 3.0.0-SNAPSHOT",
+ "arrow",
  "async-trait",
  "chrono",
  "clap 2.33.3",
@@ -509,7 +495,7 @@ dependencies = [
  "fnv",
  "futures",
  "num_cpus",
- "parquet 3.0.0-SNAPSHOT",
+ "parquet",
  "paste",
  "rustyline",
  "sqlparser",
@@ -521,7 +507,7 @@ name = "deltalake"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "arrow 3.0.0-SNAPSHOT",
+ "arrow",
  "bytes 0.5.6",
  "chrono",
  "clap 3.0.0-beta.2",
@@ -529,7 +515,7 @@ dependencies = [
  "datafusion",
  "futures",
  "log",
- "parquet 2.0.0",
+ "parquet",
  "regex",
  "rusoto_core",
  "rusoto_s3",
@@ -1468,30 +1454,11 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63bfa03025e71790395361efbcb84f1a9184ead1e608ef16971373dfe94a896e"
-dependencies = [
- "arrow 2.0.0",
- "brotli",
- "byteorder",
- "chrono",
- "flate2",
- "lz4",
- "num-bigint",
- "parquet-format",
- "snap",
- "thrift",
- "zstd",
-]
-
-[[package]]
-name = "parquet"
 version = "3.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow.git?rev=c02ed530f989c4e0343ca6ab494c17e7796ed9c1#c02ed530f989c4e0343ca6ab494c17e7796ed9c1"
 dependencies = [
- "arrow 3.0.0-SNAPSHOT",
- "base64",
+ "arrow",
+ "base64 0.13.0",
  "brotli",
  "byteorder",
  "chrono",
@@ -1809,7 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8d624cb48fcaca612329e4dd544380aa329ef338e83d3a90f5b7897e631971"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.12.3",
  "bytes 0.5.6",
  "futures",
  "hmac",
@@ -1870,7 +1837,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62940a2bd479900a1bf8935b8f254d3e19368ac3ac4570eb4bd48eb46551a1b7"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "bytes 0.5.6",
  "futures",
  "hex",
@@ -1895,7 +1862,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-parquet = "2"
 tokio = "0.2.10"
 tokio-io = "0.2.0-alpha.6"
 futures = "0.3.1"
@@ -26,6 +25,7 @@ rusoto_core = "0.43"
 rusoto_s3 = "0.43"
 arrow  = { git = "https://github.com/apache/arrow.git", rev = "c02ed530f989c4e0343ca6ab494c17e7796ed9c1" }
 datafusion = { git = "https://github.com/apache/arrow.git", rev = "c02ed530f989c4e0343ca6ab494c17e7796ed9c1", optional = true }
+parquet = { git = "https://github.com/apache/arrow.git", rev = "c02ed530f989c4e0343ca6ab494c17e7796ed9c1" }
 crossbeam = { version = "0", optional = true }
 # NOTE: disable rust-dataframe integration since it currently doesn't have a
 # version published in crates.io

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -8,7 +8,10 @@ use std::path::Path;
 
 use chrono::{DateTime, FixedOffset, Utc};
 use parquet::errors::ParquetError;
-use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::file::{
+    reader::{FileReader, SerializedFileReader},
+    serialized_reader::SliceableCursor,
+};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -322,7 +325,7 @@ impl DeltaTable {
         // process actions from checkpoint
         for f in &checkpoint_data_paths {
             let obj = self.storage.get_obj(&f)?;
-            let preader = SerializedFileReader::new(Cursor::new(obj))?;
+            let preader = SerializedFileReader::new(SliceableCursor::new(obj))?;
             let schema = preader.metadata().file_metadata().schema();
             if !schema.is_group() {
                 return Err(DeltaTableError::from(action::ActionError::Generic(


### PR DESCRIPTION
Using parquet = "2" resulted in two versions of arrow being compiled; this thins out the dependency tree a bit.