### PR TITLE
Asyncify APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -629,6 +629,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "arrow",
+ "async-trait",
  "azure_core",
  "azure_storage",
  "bytes 0.5.6",
@@ -2798,9 +2799,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -2833,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ version = "0.1.0"
 dependencies = [
  "deltalake",
  "pyo3",
+ "tokio",
 ]
 
 [[package]]
@@ -666,6 +667,7 @@ version = "0.1.0"
 dependencies = [
  "deltalake",
  "helix",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "azure_core"
 version = "0.1.0"
-source = "git+https://github.com/Azure/azure-sdk-for-rust?rev=85e37c2a3765af88873ed9cbd7ac072e920a6127#85e37c2a3765af88873ed9cbd7ac072e920a6127"
+source = "git+https://github.com/Azure/azure-sdk-for-rust?rev=bc74cad7cc5f9226cf39c4abae0d902a85765e74#bc74cad7cc5f9226cf39c4abae0d902a85765e74"
 dependencies = [
  "RustyXML",
  "async-trait",
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "azure_storage"
 version = "0.1.0"
-source = "git+https://github.com/Azure/azure-sdk-for-rust?rev=85e37c2a3765af88873ed9cbd7ac072e920a6127#85e37c2a3765af88873ed9cbd7ac072e920a6127"
+source = "git+https://github.com/Azure/azure-sdk-for-rust?rev=bc74cad7cc5f9226cf39c4abae0d902a85765e74#bc74cad7cc5f9226cf39c4abae0d902a85765e74"
 dependencies = [
  "RustyXML",
  "azure_core",

--- a/TODO
+++ b/TODO
@@ -1,4 +1,3 @@
-* make all IO async
 * handle commitInfo action
 * use list api to find transaction logs to apply
 * prefetch log content in parallel

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 name = "deltalake"
 crate-type = ["cdylib"]
 
+[dependencies]
+tokio = "0.2"
+
 [dependencies.pyo3]
 version = "0.12.*"
 features = ["extension-module"]

--- a/ruby/Cargo.toml
+++ b/ruby/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 helix = "*"
+tokio = "0.2"
 
 [dependencies.deltalake]
 path = "../rust"

--- a/ruby/src/lib.rs
+++ b/ruby/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit="1024"]
+#![recursion_limit = "1024"]
 
 #[macro_use]
 extern crate helix;
@@ -6,7 +6,6 @@ extern crate deltalake;
 
 use deltalake::DeltaTable;
 use std::sync::Arc;
-
 
 ruby! {
     class Table {
@@ -18,7 +17,8 @@ ruby! {
         def initialize(helix, table_path: String) {
             println!("initializing with {}", table_path);
 
-            let table = deltalake::open_table(&table_path).unwrap();
+            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let table = rt.block_on(deltalake::open_table(&table_path)).unwrap();
             let actual = Arc::new(table);
 
             Table {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = "0.2.10"
+tokio = { version = "0.2.23", features = ["fs", "macros", "stream"] }
 tokio-io = "0.2.0-alpha.6"
 futures = "0.3.1"
 bytes = "0.5.3"
@@ -35,6 +35,7 @@ datafusion = { git = "https://github.com/apache/arrow.git", rev = "c02ed530f989c
 parquet = { git = "https://github.com/apache/arrow.git", rev = "c02ed530f989c4e0343ca6ab494c17e7796ed9c1" }
 crossbeam = { version = "0", optional = true }
 cfg-if = "1"
+async-trait = "0.1.42"
 # NOTE: disable rust-dataframe integration since it currently doesn't have a
 # version published in crates.io
 # rust-dataframe = {version = "0.*", optional = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,8 +23,8 @@ regex = "1"
 chrono = "0"
 
 # Azure
-azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "85e37c2a3765af88873ed9cbd7ac072e920a6127" }
-azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "85e37c2a3765af88873ed9cbd7ac072e920a6127" }
+azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "bc74cad7cc5f9226cf39c4abae0d902a85765e74" }
+azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "bc74cad7cc5f9226cf39c4abae0d902a85765e74" }
 
 # S3
 rusoto_core = { version = "0.43", optional = true }

--- a/rust/src/bin/delta-inspect.rs
+++ b/rust/src/bin/delta-inspect.rs
@@ -3,7 +3,8 @@ extern crate deltalake;
 
 use clap::{App, AppSettings, Arg};
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let matches = App::new("Delta table inspector")
         .version(env!("CARGO_PKG_VERSION"))
         .about("Utility to help inspect Delta talebs")
@@ -40,11 +41,11 @@ fn main() -> anyhow::Result<()> {
             let table_path = files_matches.value_of("path").unwrap();
 
             let table = match files_matches.value_of_t::<i64>("version") {
-                Ok(v) => deltalake::open_table_with_version(table_path, v)?,
+                Ok(v) => deltalake::open_table_with_version(table_path, v).await?,
                 Err(clap::Error {
                     kind: clap::ErrorKind::ArgumentNotFound,
                     ..
-                }) => deltalake::open_table(table_path)?,
+                }) => deltalake::open_table(table_path).await?,
                 Err(e) => e.exit(),
             };
 
@@ -58,7 +59,7 @@ fn main() -> anyhow::Result<()> {
         }
         Some(("info", info_matches)) => {
             let table_path = info_matches.value_of("path").unwrap();
-            let table = deltalake::open_table(table_path)?;
+            let table = deltalake::open_table(table_path).await?;
             println!("{}", table);
         }
         _ => unreachable!(),

--- a/rust/src/storage/azure.rs
+++ b/rust/src/storage/azure.rs
@@ -119,7 +119,7 @@ impl StorageBackend for ADLSGen2Backend {
     {
         debug!("Listing objects under {}", path);
         let obj = parse_uri(path)?.into_adlsgen2_object()?;
-        let account_name = self.client.account().clone();
+        let account_name = self.client.account();
         let stream = self
             .client
             .list_blobs()

--- a/rust/src/storage/azure.rs
+++ b/rust/src/storage/azure.rs
@@ -91,8 +91,7 @@ impl StorageBackend for ADLSGen2Backend {
             .with_container_name(obj.file_system)
             .with_blob_name(obj.path)
             .finalize()
-            .await
-            .unwrap();
+            .await?;
         let modified = properties
             .blob
             .last_modified

--- a/rust/tests/azure_test.rs
+++ b/rust/tests/azure_test.rs
@@ -1,11 +1,12 @@
 #[cfg(feature = "azure")]
 mod azure {
-    #[test]
-    fn test_azure_simple() {
+    #[tokio::test]
+    async fn test_azure_simple() {
         std::env::set_var("AZURE_STORAGE_ACCOUNT", "deltarstests");
         std::env::set_var("AZURE_STORAGE_SAS", "?sv=2019-12-12&ss=b&srt=co&sp=rl&se=2050-12-31T23:59:59Z&st=2020-11-30T10:19:31Z&spr=https&sig=%2FVV88TK0pwkY%2FoF3qXwweisDs63gfzdBlHAhB1zsED8%3D");
         let table =
             deltalake::open_table("abfss://simple@deltarstests.dfs.core.windows.net/simple/table")
+                .await
                 .unwrap();
         println!("{}", table);
         assert_eq!(table.version, 4);

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -11,7 +11,9 @@ mod datafusion {
     #[tokio::test]
     async fn test_datafusion_simple_query() -> Result<()> {
         let mut ctx = ExecutionContext::new();
-        let table = deltalake::open_table("./tests/data/simple_table").unwrap();
+        let table = deltalake::open_table("./tests/data/simple_table")
+            .await
+            .unwrap();
         ctx.register_table("demo", Box::new(table));
 
         let plan = ctx.create_logical_plan("SELECT id FROM demo WHERE id > 5")?;

--- a/rust/tests/read_delta-0-2-0_test.rs
+++ b/rust/tests/read_delta-0-2-0_test.rs
@@ -1,8 +1,10 @@
 extern crate deltalake;
 
-#[test]
-fn read_delta_2_0_table_without_version() {
-    let table = deltalake::open_table("./tests/data/delta-0.2.0").unwrap();
+#[tokio::test]
+async fn read_delta_2_0_table_without_version() {
+    let table = deltalake::open_table("./tests/data/delta-0.2.0")
+        .await
+        .unwrap();
     assert_eq!(table.version, 3);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -26,9 +28,11 @@ fn read_delta_2_0_table_without_version() {
     );
 }
 
-#[test]
-fn read_delta_2_0_table_with_version() {
-    let mut table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 0).unwrap();
+#[tokio::test]
+async fn read_delta_2_0_table_with_version() {
+    let mut table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 0)
+        .await
+        .unwrap();
     assert_eq!(table.version, 0);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -40,7 +44,9 @@ fn read_delta_2_0_table_with_version() {
         ],
     );
 
-    table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 2).unwrap();
+    table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 2)
+        .await
+        .unwrap();
     assert_eq!(table.version, 2);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -52,7 +58,9 @@ fn read_delta_2_0_table_with_version() {
         ]
     );
 
-    table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 3).unwrap();
+    table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 3)
+        .await
+        .unwrap();
     assert_eq!(table.version, 3);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -6,9 +6,11 @@ use std::path::Path;
 
 use self::chrono::{DateTime, FixedOffset, Utc};
 
-#[test]
-fn read_simple_table() {
-    let table = deltalake::open_table("./tests/data/simple_table").unwrap();
+#[tokio::test]
+async fn read_simple_table() {
+    let table = deltalake::open_table("./tests/data/simple_table")
+        .await
+        .unwrap();
     assert_eq!(table.version, 4);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -34,9 +36,11 @@ fn read_simple_table() {
     );
 }
 
-#[test]
-fn read_simple_table_with_version() {
-    let mut table = deltalake::open_table_with_version("./tests/data/simple_table", 0).unwrap();
+#[tokio::test]
+async fn read_simple_table_with_version() {
+    let mut table = deltalake::open_table_with_version("./tests/data/simple_table", 0)
+        .await
+        .unwrap();
     assert_eq!(table.version, 0);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -52,7 +56,9 @@ fn read_simple_table_with_version() {
         ],
     );
 
-    table = deltalake::open_table_with_version("./tests/data/simple_table", 2).unwrap();
+    table = deltalake::open_table_with_version("./tests/data/simple_table", 2)
+        .await
+        .unwrap();
     assert_eq!(table.version, 2);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -68,7 +74,9 @@ fn read_simple_table_with_version() {
         ]
     );
 
-    table = deltalake::open_table_with_version("./tests/data/simple_table", 3).unwrap();
+    table = deltalake::open_table_with_version("./tests/data/simple_table", 3)
+        .await
+        .unwrap();
     assert_eq!(table.version, 3);
     assert_eq!(table.min_writer_version, 2);
     assert_eq!(table.min_reader_version, 1);
@@ -90,8 +98,8 @@ fn ds_to_ts(ds: &str) -> i64 {
     DateTime::<Utc>::from(fixed_dt).timestamp()
 }
 
-#[test]
-fn time_travel_by_ds() {
+#[tokio::test]
+async fn time_travel_by_ds() {
     // git does not preserve mtime, so we need to manually set it in the test
     let log_dir = "./tests/data/simple_table/_delta_log";
     let log_mtime_pair = vec![
@@ -109,34 +117,42 @@ fn time_travel_by_ds() {
 
     let mut table =
         deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-01T00:47:31-07:00")
+            .await
             .unwrap();
     assert_eq!(table.version, 0);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-02T22:47:31-07:00")
+        .await
         .unwrap();
     assert_eq!(table.version, 1);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-02T23:47:31-07:00")
+        .await
         .unwrap();
     assert_eq!(table.version, 1);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-03T22:47:31-07:00")
+        .await
         .unwrap();
     assert_eq!(table.version, 2);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-04T22:47:31-07:00")
+        .await
         .unwrap();
     assert_eq!(table.version, 3);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-05T21:47:31-07:00")
+        .await
         .unwrap();
     assert_eq!(table.version, 3);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-05T22:47:31-07:00")
+        .await
         .unwrap();
     assert_eq!(table.version, 4);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-25T22:47:31-07:00")
+        .await
         .unwrap();
     assert_eq!(table.version, 4);
 }


### PR DESCRIPTION
This PR makes the `StorageBackend` trait methods async (using `async_trait`), and changes the implementations for file/Azure/S3 to be async. The `list_obj` methods now returns a `Stream<Item = Result<ObjectMeta, StorageError>>` instead of an iterator.

This change ends up propagating all the way back to the main entrypoints, since those functions do quite a lot of IO to get data from the storage backend. Not 100% how that could affect the Python APIs yet - perhaps I should look into it before this is merged - but I thought it could be worth pushing this up as-is.

I don't have any way of testing this against S3 directly unfortunately; it would be good to get tests for a large number of objects to test the continuation token code.